### PR TITLE
Add first pass at an edX configuration for stylelint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: 'eslint-config-edx',
+  root: true,
+  settings: {
+    'import/resolver': 'webpack',
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+nodeenv

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.gitignore
+.npmignore
+.travis.yml
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+
+sudo: false
+
+node_js:
+    - 8
+
+install:
+    - npm install
+
+script:
+    - npm run test
+
+branches:
+    only:
+      - master

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ The only changes are that the following rules have been disabled:
  - [function-parentheses-newline-inside](https://stylelint.io/user-guide/rules/function-parentheses-newline-inside/)
  - [max-empty-lines](https://stylelint.io/user-guide/rules/max-empty-lines/)
  - [number-leading-zero](https://stylelint.io/user-guide/rules/number-leading-zero/)
+ - [selector-list-comma-newline-after](https://stylelint.io/user-guide/rules/selector-list-comma-newline-after/)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
-# stylelint-config-edx
-Stylelint configs for edX Sass files
+# edX Stylelint configs
+[![Build Status](https://travis-ci.org/edx/stylelint-config-edx.svg?branch=master)](https://travis-ci.org/edx/eslint-config-edx)
+
+Stylelint configs for edX Sass files.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [License](#license)
+3. [Dependencies](#dependencies)
+4. [Usage](#usage)
+5. [The Configs](#the-configs)
+
+## Overview
+
+In order to standardize and enforce edX's Sass coding style across
+multiple codebases, edX has adopted Stylelint. This package provides
+the rules defined by the edX development community.
+
+## License
+
+The code in this repository is released under the Apache 2.0 license
+unless otherwise noted. Please see the [LICENSE
+file](https://github.com/edx/eslint-config-edx/blob/master/LICENSE) for
+details.
+
+## Dependencies
+
+[ESLint](http://eslint.org) is required to use either config, and NodeJS
+4.0 or greater is required to use ESLint. Both configs are tested with
+the Node version bundled in the [most recent edX devstack
+setup](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/devstack/install_devstack.html).
+
+## Usage
+
+To begin using the edX ESLint configs in a codebase, install this
+package from npm:
+
+    npm install --save-dev stylelint-config-edx
+
+Then, configure your project's ESLint config to extend
+`stylelint-config-edx` (see the ESLint docs
+on [Using a Shareable
+Config](http://eslint.org/docs/developer-guide/shareable-configs#using-a-shareable-config)).
+If you do not plan on adding custom rules beyond those in
+`eslint-config-edx` to your project, the easiest place to configure this
+is probably in your `package.json`:
+
+    "devDependencies": {
+        "eslint-config-edx": "^2.0.0"
+    },
+    "eslintConfig": {
+        "extends": "eslint-config-edx"
+    }
+
+If you plan on adding additional customization, you can [configure your
+project with an `.eslintrc.js`/`.eslintrc.json`
+file](http://eslint.org/docs/user-guide/configuring#configuration-file-formats).
+
+## The Configs
+
+More documentation on the rules specified by each config is available in:
+
+- [the README for `eslint-config-edx`](https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx/README.md)
+- [the README for `eslint-config-edx-es5`](https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx-es5/README.md)

--- a/README.md
+++ b/README.md
@@ -24,42 +24,34 @@ unless otherwise noted. Please see the [LICENSE
 file](https://github.com/edx/eslint-config-edx/blob/master/LICENSE) for
 details.
 
-## Dependencies
-
-[ESLint](http://eslint.org) is required to use either config, and NodeJS
-4.0 or greater is required to use ESLint. Both configs are tested with
-the Node version bundled in the [most recent edX devstack
-setup](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/devstack/install_devstack.html).
-
 ## Usage
 
-To begin using the edX ESLint configs in a codebase, install this
+To begin using the edX Stylelint configs in a codebase, install this
 package from npm:
 
     npm install --save-dev stylelint-config-edx
 
-Then, configure your project's ESLint config to extend
+Then, configure your project's Stylelint config to extend
 `stylelint-config-edx` (see the ESLint docs
 on [Using a Shareable
-Config](http://eslint.org/docs/developer-guide/shareable-configs#using-a-shareable-config)).
-If you do not plan on adding custom rules beyond those in
-`eslint-config-edx` to your project, the easiest place to configure this
-is probably in your `package.json`:
+Config](https://stylelint.io/user-guide/configuration/#extends)).
 
-    "devDependencies": {
-        "eslint-config-edx": "^2.0.0"
-    },
-    "eslintConfig": {
-        "extends": "eslint-config-edx"
-    }
+The simplest option is to add the following to a file
+`stylelint.config.js` at the root of your repository:
 
-If you plan on adding additional customization, you can [configure your
-project with an `.eslintrc.js`/`.eslintrc.json`
-file](http://eslint.org/docs/user-guide/configuring#configuration-file-formats).
+    module.exports = {
+      extends: 'stylelint-config-edx'
+    };
 
-## The Configs
 
-More documentation on the rules specified by each config is available in:
+## Sass Style Guide
 
-- [the README for `eslint-config-edx`](https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx/README.md)
-- [the README for `eslint-config-edx-es5`](https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx-es5/README.md)
+For the most part, edX follows the recommended SCSS rules defined
+by the [stylelint-config-recommended-scss package](https://www.npmjs.com/package/stylelint-config-recommended-scss).
+
+The only changes are that the following rules have been disabled:
+
+ - [function-comma-newline-after](https://stylelint.io/user-guide/rules/function-comma-newline-after/)
+ - [function-parentheses-newline-inside](https://stylelint.io/user-guide/rules/function-parentheses-newline-inside/)
+ - [max-empty-lines](https://stylelint.io/user-guide/rules/max-empty-lines/)
+ - [number-leading-zero](https://stylelint.io/user-guide/rules/number-leading-zero/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-edx",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Stylelint configs for edX Sass files.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "stylelint-config-edx",
+  "version": "0.1.0",
+  "description": "Stylelint configs for edX Sass files.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/edx/stylelint-config-edx.git"
+  },
+  "keywords": [
+    "edx",
+    "linter",
+    "sass",
+    "stylelint",
+    "stylelint-config"
+  ],
+  "homepage": "https://github.com/edx/edx-stylelint-config-edx#readme",
+  "dependencies": {
+    "stylelint": "^8.1.1",
+    "stylelint-config-recommended-scss": "^2.0.0",
+    "stylelint-config-standard": "^17.0.0",
+    "stylelint-scss": "^2.1.0"
+  },
+  "devDependencies": {
+    "eslint-config-edx": "^4.0.0"
+  },
+  "main": "stylelint.config.js",
+  "files": [
+    "stylelint.config.js"
+  ],
+  "scripts": {
+    "lint-js": "eslint . --ignore-path .gitignore",
+    "quality": "npm run lint-js",
+    "test": "npm run quality"
+  }
+}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ['stylelint-config-standard', 'stylelint-config-recommended-scss'],
+  rules: {
+    'function-comma-newline-after': null,
+    'function-parentheses-newline-inside': null,
+    'max-empty-lines': null,
+    'number-leading-zero': null,
+  },
+};

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,5 +5,6 @@ module.exports = {
     'function-parentheses-newline-inside': null,
     'max-empty-lines': null,
     'number-leading-zero': null,
+    'selector-list-comma-newline-after': null,
   },
 };


### PR DESCRIPTION
https://openedx.atlassian.net/browse/FEDX-380

This is a first cut at an edX-wide configuration for Sass linting using [stylelint](https://stylelint.io). I'm also using the plugin [stylelint-scss](https://www.npmjs.com/package/stylelint-scss) to add Sass-specific rules. 

To see it in action, I have PRs to add it to two repos:

* https://github.com/edx/edx-bootstrap/pull/8
* https://github.com/edx/edx-platform/pull/15982

I've added a few rule exclusions to this repo based upon idioms that seemed reasonable in these two PRs. Let's discuss on this PR if they all make sense, and if there are other rules that we should be excluding.

FYI @edx/fedx-team