### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # edX Stylelint configs
-[![Build Status](https://travis-ci.org/edx/stylelint-config-edx.svg?branch=master)](https://travis-ci.org/edx/eslint-config-edx)
+[![Build Status](https://travis-ci.com/edx/stylelint-config-edx.svg?branch=master)](https://travis-ci.com/edx/eslint-config-edx)
 
 Stylelint configs for edX Sass files.
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089